### PR TITLE
Upgrade to 1.4.1

### DIFF
--- a/spring-boot-admin/pom.xml
+++ b/spring-boot-admin/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.2.2.RELEASE</version>
+		<version>1.4.0.RELEASE</version>
 	</parent>
 
     <groupId>com.peiniau.spring</groupId>
@@ -25,12 +25,12 @@
         <dependency>
             <groupId>de.codecentric</groupId>
             <artifactId>spring-boot-admin-server</artifactId>
-            <version>1.1.2</version>
+            <version>1.4.1</version>
         </dependency>
         <dependency>
             <groupId>de.codecentric</groupId>
             <artifactId>spring-boot-admin-server-ui</artifactId>
-            <version>1.1.2</version>
+            <version>1.4.1</version>
         </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-boot-webapp-1/pom.xml
+++ b/spring-boot-webapp-1/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.2.2.RELEASE</version>
+		<version>1.4.0.RELEASE</version>
 	</parent>
 
     <groupId>com.peiniau.spring</groupId>
@@ -32,8 +32,8 @@
 		</dependency>
         <dependency>
             <groupId>de.codecentric</groupId>
-            <artifactId>spring-boot-starter-admin-client</artifactId>
-            <version>1.1.2</version>
+            <artifactId>spring-boot-admin-starter-client</artifactId>
+            <version>1.4.1</version>
         </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-boot-webapp-1/src/main/resources/application.properties
+++ b/spring-boot-webapp-1/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.boot.admin.url=http://admin:8080
+spring.boot.admin.client.prefer-ip=true

--- a/spring-boot-webapp-2/pom.xml
+++ b/spring-boot-webapp-2/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.2.2.RELEASE</version>
+		<version>1.4.0.RELEASE</version>
 	</parent>
 
     <groupId>com.peiniau.spring</groupId>
@@ -32,8 +32,8 @@
 		</dependency>
         <dependency>
             <groupId>de.codecentric</groupId>
-            <artifactId>spring-boot-starter-admin-client</artifactId>
-            <version>1.1.2</version>
+            <artifactId>spring-boot-admin-starter-client</artifactId>
+            <version>1.4.1</version>
         </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-boot-webapp-2/src/main/resources/application.properties
+++ b/spring-boot-webapp-2/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.boot.admin.url=http://admin:8080
+spring.boot.admin.client.prefer-ip=true


### PR DESCRIPTION
Hi,

while upgrading to Spring Boot 1.4.0 and spring-boot-admin 1.4.1
links for inter-container communication do not work anymore

``` bash
web1_1   | 2016-09-14 07:52:25.129  INFO 1 --- [pool-1-thread-1] d.c.b.a.services.ApplicationRegistrator  : Application registered itself as {managementUrl=http://8fa0cab6976e:8080, healthUrl=http://8fa0cab6976e:8080/health, serviceUrl=http://8fa0cab6976e:8080, name=spring-boot-application, id=4e31a41b, statusInfo={status=UNKNOWN, timestamp=1473839544751}}
web2_1   | 2016-09-14 07:52:25.164  INFO 1 --- [pool-1-thread-1] d.c.b.a.services.ApplicationRegistrator  : Application registered itself as {managementUrl=http://7529f2816f5a:8080, healthUrl=http://7529f2816f5a:8080/health, serviceUrl=http://7529f2816f5a:8080, name=spring-boot-application, id=55189c90, statusInfo={status=UNKNOWN, timestamp=1473839544746}}
```

previously we had:

``` bash
admin_1  | 2016-09-14 07:37:18.201  INFO 1 --- [nio-8080-exec-1] d.c.b.a.registry.ApplicationRegistry     : New Application [id=3f42f2d1, url=http://localhost:8082, name=spring-boot-application] registered 
admin_1  | 2016-09-14 07:37:27.363  INFO 1 --- [nio-8080-exec-2] d.c.b.a.registry.ApplicationRegistry     : New Application [id=bc6c4174, url=http://localhost:8081, name=spring-boot-application] registered 
```

after upgrade

``` bash
admin_1  | 2016-09-14 07:52:24.746  INFO 1 --- [nio-8080-exec-1] d.c.b.a.registry.ApplicationRegistry     : New Application Application [id=55189c90, name=spring-boot-application, managementUrl=http://7529f2816f5a:8080, healthUrl=http://7529f2816f5a:8080/health, serviceUrl=http://7529f2816f5a:8080] registered 
admin_1  | 2016-09-14 07:52:24.751  INFO 1 --- [nio-8080-exec-2] d.c.b.a.registry.ApplicationRegistry     : New Application Application [id=4e31a41b, name=spring-boot-application, managementUrl=http://8fa0cab6976e:8080, healthUrl=http://8fa0cab6976e:8080/health, serviceUrl=http://8fa0cab6976e:8080] registered 
admin_1  | 2016-09-14 07:52:24.923  WARN 1 --- [nio-8080-exec-1] d.c.boot.admin.registry.StatusUpdater    : Couldn't retrieve status for Application [id=55189c90, name=spring-boot-application, managementUrl=http://7529f2816f5a:8080, healthUrl=http://7529f2816f5a:8080/health, serviceUrl=http://7529f2816f5a:8080]
admin_1  | 
admin_1  | org.springframework.web.client.ResourceAccessException: I/O error on GET request for "http://7529f2816f5a:8080/health": 7529f2816f5a: unknown error; nested exception is java.net.UnknownHostException: 7529f2816f5a: unknown error
```

Do you have any idea what is causing the problem?

cc @codecentric
